### PR TITLE
Fixes iOS 11 issue

### DIFF
--- a/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
+++ b/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
@@ -56,21 +56,11 @@ open class KeyboardLayoutGuide: UILayoutGuide {
         guard let view = owningView else {
             return
         }
-        
-        if #available(iOS 11.0, *) {
-            NSLayoutConstraint.activate([
-                heightAnchor.constraint(equalToConstant: Keyboard.shared.currentHeight),
-                leftAnchor.constraint(equalTo: view.leftAnchor),
-                rightAnchor.constraint(equalTo: view.rightAnchor),
-                ])
-        } else {
-            NSLayoutConstraint.activate([
-                heightAnchor.constraint(equalToConstant: 0),
-                leftAnchor.constraint(equalTo: view.leftAnchor),
-                rightAnchor.constraint(equalTo: view.rightAnchor),
-                ])
-        }
-        
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: Keyboard.shared.currentHeight),
+            leftAnchor.constraint(equalTo: view.leftAnchor),
+            rightAnchor.constraint(equalTo: view.rightAnchor),
+        ])
         let viewBottomAnchor: NSLayoutYAxisAnchor
         if #available(iOS 11.0, *) {
             viewBottomAnchor = view.safeAreaLayoutGuide.bottomAnchor
@@ -88,9 +78,7 @@ open class KeyboardLayoutGuide: UILayoutGuide {
             }
             heightConstraint?.constant = height
             animate(note)
-            if #available(iOS 11.0, *) {
-                Keyboard.shared.currentHeight = height
-            }
+            Keyboard.shared.currentHeight = height
         }
     }
     

--- a/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
+++ b/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
@@ -8,6 +8,11 @@
 
 import UIKit
 
+private class Keyboard {
+    static let shared = Keyboard()
+    var currentHeight: CGFloat = 0
+}
+
 public extension UIView {
     
     private struct AssociatedKeys {
@@ -51,11 +56,21 @@ open class KeyboardLayoutGuide: UILayoutGuide {
         guard let view = owningView else {
             return
         }
-        NSLayoutConstraint.activate([
-            heightAnchor.constraint(equalToConstant: 0),
-            leftAnchor.constraint(equalTo: view.leftAnchor),
-            rightAnchor.constraint(equalTo: view.rightAnchor),
-            ])
+        
+        if #available(iOS 11.0, *) {
+            NSLayoutConstraint.activate([
+                heightAnchor.constraint(equalToConstant: Keyboard.shared.currentHeight),
+                leftAnchor.constraint(equalTo: view.leftAnchor),
+                rightAnchor.constraint(equalTo: view.rightAnchor),
+                ])
+        } else {
+            NSLayoutConstraint.activate([
+                heightAnchor.constraint(equalToConstant: 0),
+                leftAnchor.constraint(equalTo: view.leftAnchor),
+                rightAnchor.constraint(equalTo: view.rightAnchor),
+                ])
+        }
+        
         let viewBottomAnchor: NSLayoutYAxisAnchor
         if #available(iOS 11.0, *) {
             viewBottomAnchor = view.safeAreaLayoutGuide.bottomAnchor
@@ -73,6 +88,9 @@ open class KeyboardLayoutGuide: UILayoutGuide {
             }
             heightConstraint?.constant = height
             animate(note)
+            if #available(iOS 11.0, *) {
+                Keyboard.shared.currentHeight = height
+            }
         }
     }
     


### PR DESCRIPTION
We have a set of signup screens that are pushed one after another.

Everything works fine if we call `becomeFirstResponder()` in `viewDidAppear`
the `keyboardWillChangeFrame` is called and everything works as expected.

The thing is calling `becomeFirstResponder` in `viewDidAppear` animates the keyboard.

If we want to have the keyboard stay in position (already shown) in the screens,
we can call `becomeFirstResponder` in viewDidLoad.

In iOS 11, the issue is that the keyboard notifications are not called if the keyboard is already on screen
so we end up with the button under the keyboard.
The underlying reason is that `keyboardWillChangeFrame` is not called on IOS11 if the keyboard stays shown between controllers, which seems quite logical actually.

The fix stores the previous keyboard height and sets in back up when setting up a new controller, only if the device is running iOS 11 :)