### PR TITLE
Pull the safe area inset off of the key window

### DIFF
--- a/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
+++ b/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
@@ -74,7 +74,9 @@ open class KeyboardLayoutGuide: UILayoutGuide {
     private func keyboardWillChangeFrame(_ note: Notification) {
         if var height = note.keyboardHeight {
             if #available(iOS 11.0, *), height > 0 {
-                height -= (owningView?.safeAreaInsets.bottom)!
+                if let keyWindow = UIApplication.shared.keyWindow {
+                    height -= keyWindow.safeAreaInsets.bottom
+                }
             }
             heightConstraint?.constant = height
             animate(note)


### PR DESCRIPTION
Views that are placed inside of of the safe area and aren't touching the edges don't have a safe area. Since the keyboard takes into account safe area anyway, pulling safe area off of the owning view doesn't work sometimes. This fixes that issue.