### PR TITLE
Make the height difference in the keyboard guide reflect the key window’s safeAreaInsets instead of the owning view’s

### DIFF
--- a/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
+++ b/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
@@ -72,12 +72,18 @@ open class KeyboardLayoutGuide: UILayoutGuide {
     
     @objc
     private func keyboardWillChangeFrame(_ note: Notification) {
-        if var height = note.keyboardHeight {
-            if #available(iOS 11.0, *), height > 0 {
-                if let keyWindow = UIApplication.shared.keyWindow {
-                    height -= keyWindow.safeAreaInsets.bottom
+        if var height = note.keyboardHeight, let owningView = owningView {
+            if let window = owningView.window {
+                if #available(iOS 11.0, *) {
+                    height -= window.safeAreaInsets.bottom
                 }
+
+                let localBottomPoint = CGPoint(x: 0, y: owningView.frame.maxY)
+                let globalBottomPoint = owningView.convert(localBottomPoint, to: window)
+                let globalBottomOffset = window.frame.maxY - globalBottomPoint.y
+                height = max(0, height - globalBottomOffset)
             }
+
             heightConstraint?.constant = height
             animate(note)
             Keyboard.shared.currentHeight = height

--- a/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
+++ b/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
@@ -74,7 +74,9 @@ open class KeyboardLayoutGuide: UILayoutGuide {
     private func keyboardWillChangeFrame(_ note: Notification) {
         if var height = note.keyboardHeight {
             if #available(iOS 11.0, *), height > 0 {
-                height -= (owningView?.safeAreaInsets.bottom)!
+                if let keyWindow = UIApplication.shared.keyWindow {
+                    height -= keyWindow.safeAreaInsets.bottom
+                }
             }
             heightConstraint?.constant = height
             animate(note)


### PR DESCRIPTION
Views that are placed inside of of the safe area and aren't touching the edges don't have a safe area. Since the keyboard takes into account safe area anyway, pulling safe area off of the owning view doesn't work sometimes. This fixes that issue.