### PR TITLE
Fix keyboard height for slide-over mode on iPad

### DIFF
--- a/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
+++ b/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
@@ -118,7 +118,7 @@ extension Notification {
         }
         // Weirdly enough UIKeyboardFrameEndUserInfoKey doesn't have the same behaviour
         // in ios 10 or iOS 11 so we can't rely on v.cgRectValue.width
-        return UIScreen.main.bounds.height - v.cgRectValue.minY
+        return (UIApplication.shared.keyWindow?.bounds.height)! - v.cgRectValue.minY
     }
 }
 


### PR DESCRIPTION
This fixes wrong keyboard height estimation when app is launched in slide-over mode on iPads.
Please see the attached screenshots.

![patch_screens](https://user-images.githubusercontent.com/5349612/37968007-ceb8e128-31ee-11e8-96ab-fdd7ff67035e.png)
