### PR TITLE
Adds usesSafeArea to opt out of safe Area behaviour

### DIFF
--- a/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
+++ b/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
@@ -17,7 +17,7 @@ extension UIView {
     private enum AssociatedKeys {
         static var keyboardLayoutGuide = "keyboardLayoutGuide"
     }
-
+    
     /// A layout guide representing the inset for the keyboard.
     /// Use this layout guide’s top anchor to create constraints pinning to the top of the keyboard.
     public var keyboardLayoutGuide: KeyboardLayoutGuide {
@@ -33,11 +33,19 @@ extension UIView {
 }
 
 open class KeyboardLayoutGuide: UILayoutGuide {
+    public var usesSafeArea = true {
+        didSet {
+            updateButtomAnchor()
+        }
+    }
+    
+    private var bottomConstraint: NSLayoutConstraint?
+    
     @available(*, unavailable)
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     public init(notificationCenter: NotificationCenter = NotificationCenter.default) {
         super.init()
         // Observe keyboardWillChangeFrame notifications
@@ -48,7 +56,7 @@ open class KeyboardLayoutGuide: UILayoutGuide {
             object: nil
         )
     }
-
+    
     internal func setUp() {
         guard let view = owningView else { return }
         NSLayoutConstraint.activate(
@@ -58,19 +66,31 @@ open class KeyboardLayoutGuide: UILayoutGuide {
                 rightAnchor.constraint(equalTo: view.rightAnchor),
             ]
         )
+        updateButtomAnchor()
+    }
+    
+    func updateButtomAnchor() {
+        if let bottomConstraint = bottomConstraint {
+            bottomConstraint.isActive = false
+        }
+        
+        guard let view = owningView else { return }
+        
         let viewBottomAnchor: NSLayoutYAxisAnchor
-        if #available(iOS 11.0, *) {
+        if #available(iOS 11.0, *), usesSafeArea {
             viewBottomAnchor = view.safeAreaLayoutGuide.bottomAnchor
         } else {
             viewBottomAnchor = view.bottomAnchor
         }
-        bottomAnchor.constraint(equalTo: viewBottomAnchor).isActive = true
+        
+        bottomConstraint = bottomAnchor.constraint(equalTo: viewBottomAnchor)
+        bottomConstraint?.isActive = true
     }
-
+    
     @objc
     private func keyboardWillChangeFrame(_ note: Notification) {
         if var height = note.keyboardHeight {
-            if #available(iOS 11.0, *), height > 0, let bottom = owningView?.safeAreaInsets.bottom {
+            if #available(iOS 11.0, *), usesSafeArea, height > 0, let bottom = owningView?.safeAreaInsets.bottom {
                 height -= bottom
             }
             heightConstraint?.constant = height
@@ -78,7 +98,7 @@ open class KeyboardLayoutGuide: UILayoutGuide {
             Keyboard.shared.currentHeight = height
         }
     }
-
+    
     private func animate(_ note: Notification) {
         if
             let owningView = self.owningView,

--- a/KeyboardLayoutGuideExample/KeyboardLayoutGuideExample/ViewController.swift
+++ b/KeyboardLayoutGuideExample/KeyboardLayoutGuideExample/ViewController.swift
@@ -16,6 +16,9 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // Opt out of safe area if needed.
+        view.keyboardLayoutGuide.usesSafeArea = false
+        
         // Constrain your button to the keyboardLayoutGuide's top Anchor the way you would do natively :)
         button.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor).isActive = true
     }


### PR DESCRIPTION
Based on @moyerr 's idea in  https://github.com/freshOS/KeyboardLayoutGuide/issues/23
this introduces usesSafeArea to opt out of default safe Area behaviour.

```swift
// Opt out of safe area if needed.
view.keyboardLayoutGuide.usesSafeArea = false
```