### PR TITLE
Fix for animation glitch when swithcing from a normal textfiled to a password textflied

### DIFF
--- a/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
+++ b/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
@@ -89,11 +89,14 @@ open class KeyboardLayoutGuide: UILayoutGuide {
 
     @objc
     private func keyboardWillChangeFrame(_ note: Notification) {
-        if var height = note.keyboardHeight {
+        if var height = note.keyboardHeight, let duration = note.animationDuration {
             if #available(iOS 11.0, *), usesSafeArea, height > 0, let bottom = owningView?.safeAreaInsets.bottom {
                 height -= bottom
             }
             heightConstraint?.constant = height
+            if duration > 0.0 {
+                animate(note)
+            }
             animate(note)
             Keyboard.shared.currentHeight = height
         }
@@ -132,6 +135,10 @@ extension Notification {
         // in ios 10 or iOS 11 so we can't rely on v.cgRectValue.width
         let screenHeight = UIApplication.shared.keyWindow?.bounds.height ?? UIScreen.main.bounds.height
         return screenHeight - keyboardFrame.cgRectValue.minY
+    }
+    
+    var animationDuration: CGFloat? {
+        return self.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? CGFloat
     }
 }
 

--- a/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
+++ b/KeyboardLayoutGuide/KeyboardLayoutGuide/Keyboard+LayoutGuide.swift
@@ -97,7 +97,6 @@ open class KeyboardLayoutGuide: UILayoutGuide {
             if duration > 0.0 {
                 animate(note)
             }
-            animate(note)
             Keyboard.shared.currentHeight = height
         }
     }


### PR DESCRIPTION
Hello, 

First of all congrats for the lightweight and great implementation. It's the best i've seen so far.
There is a bug where when switching the first responder from a normal textfield to a secured textfield, a weird animation is performed. This is cause because for some reason the keyboardWillChangeFrame notification is called not once but three times, the first one being a weird value.  In order to fix this, we just have to perform the change animated only when the duration specified in the notification is greater than 0. 

Here is a screen recording of the bug: https://my.pcloud.com/publink/show?code=XZO6ibkZ92g9nOy76gbtm7VTohGNg0GDcq27